### PR TITLE
fix gdf reader id parsing 

### DIFF
--- a/tests/FSharp.FGL.Tests.NetCore/TestFiles/TestFileWrite.txt
+++ b/tests/FSharp.FGL.Tests.NetCore/TestFiles/TestFileWrite.txt
@@ -1,8 +1,8 @@
-nodedef>name VARCHAR,class VARCHAR,color VARCHAR,height DOUBLE,label VARCHAR,labelvisible BOOLEAN,visible BOOLEAN,width DOUBLE,x DOUBLE,y DOUBLE
+nodedef> name VARCHAR,class VARCHAR,color VARCHAR,height DOUBLE,label VARCHAR,labelvisible BOOLEAN,visible BOOLEAN,width DOUBLE,x DOUBLE,y DOUBLE
 s1,blog,'114,116,177',10.000000,SiteA,true,true,10.000000,-52.112960,-25.921143
 s2,forum,'219,116,251',10.986123,SiteB,true,true,10.986123,-20.114172,25.740356
 s3,webpage,'192,208,223',10.986123,SiteC,true,true,10.986123,8.598924,-26.867584
-edgedef>node1 VARCHAR,node2 VARCHAR,color VARCHAR,directed BOOLEAN
+edgedef> node1,node2,color VARCHAR,directed BOOLEAN
 s1,s2,'114,116,177',true
 s2,s3,'219,116,251',true
 s3,s1,'192,208,223',true

--- a/tests/FSharp.FGL.Tests.NetCore/TestFiles/TestFileWrite2.txt
+++ b/tests/FSharp.FGL.Tests.NetCore/TestFiles/TestFileWrite2.txt
@@ -1,0 +1,9 @@
+nodedef> name VARCHAR,class VARCHAR,color VARCHAR,height DOUBLE,label VARCHAR,labelvisible BOOLEAN,visible BOOLEAN,width DOUBLE,x DOUBLE,y DOUBLE
+s1, ,'114,116,177',10.000000,SiteA,true,true,10.000000,-52.112960,-25.921143
+s2,forum,'219,116,251',10.986123,SiteB,true,true,10.986123,-20.114172,25.740356
+s3,webpage,'192,208,223',10.986123,SiteC,true,true,10.986123,8.598924,-26.867584
+edgedef> node1,node2,color VARCHAR,directed BOOLEAN
+s1,s2, ,true
+s2,s3,'219,116,251',true
+s3,s1,'192,208,223',true
+s3,s2,'192,208,223',true

--- a/tests/FSharp.FGL.Tests.NetCore/coverage.xml.637466126583398890L.exn
+++ b/tests/FSharp.FGL.Tests.NetCore/coverage.xml.637466126583398890L.exn
@@ -1,0 +1,25 @@
+ModuleId = "6E-14-87-FF-3E-F3-FD-01-F3-16-41-B7-11-FF-BA-6D-37-0A-10-5D"
+hitPointId = 45
+context = Null
+exception = System.NullReferenceException: Object reference not set to an instance of an object.
+   at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
+   at System.Collections.Generic.Dictionary`2.ContainsKey(TKey key)
+   at AltCover.Recorder.Counter.I.ensurePoint(Dictionary`2 counts, Int32 hitPointId)
+   at AltCover.Recorder.Counter.addSingleVisit(Dictionary`2 counts, String moduleId, Int32 hitPointId, Track context)
+   at AltCover.Recorder.Instance.I.addVisit(String moduleId, Int32 hitPointId, Track context)
+   at AltCover.Recorder.Instance.I.logException[a,b,c,d](a moduleId, b hitPointId, c context, d x)
+   at AltCover.Recorder.Instance.I.addVisit(String moduleId, Int32 hitPointId, Track context)
+   at AltCover.Recorder.Instance.I.visitImpl@292.Invoke(String moduleId, Int32 hitPointId, Track context)
+   at AltCover.Recorder.Instance.I.visitImpl(String moduleId, Int32 hitPointId, Track context)
+   at FSharp.FGL.IO.GDF.fromArray(String[] data)
+   at IOTests.testGDFReaderFuntions@27-1.Invoke(Unit unitVar0)
+   at Expecto.Impl.execTestAsync@566-1.Invoke(Unit unitVar)
+   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvoke[T,TResult](AsyncActivation`1 ctxt, TResult result1, FSharpFunc`2 part2)
+   at <StartupCode$FSharp-Core>.$Async.StartChild@1666-5.Invoke(AsyncActivation`1 ctxt)
+   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction)
+   at Microsoft.FSharp.Control.TrampolineHolder.ExecuteWithTrampoline(FSharpFunc`2 firstAction)
+   at <StartupCode$FSharp-Core>.$Async.-ctor@163-1.Invoke(Object o)
+   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute()
+   at System.Threading.ThreadPoolWorkQueue.Dispatch()
+   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
+


### PR DESCRIPTION
Applied changes according to issue #19. Now Gephi gdf files can be read and are written accordingly.

Changes:

1. Header annotation of int type was updated to be written as INTEGER.
2. Node-IDs are now expected to be strings, as are all node-IDs that gephi .gdf files show.
3. "nodedef>name" and egedef>node1" were written as "nodedef> name" and egedef> node1" by gephi. Now, the spaces inbetween are readable.