### PR TITLE
Adding shortest path calculation and some centrality measures 

### DIFF
--- a/src/FSharp.ArrayAdjacencyGraph/FSharp.FGL.ArrayAdjacencyGraph.fsproj
+++ b/src/FSharp.ArrayAdjacencyGraph/FSharp.FGL.ArrayAdjacencyGraph.fsproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Include="Graph.fs" />
+    <Compile Include="Measures.fs" />
     <Compile Include="Models\BollobasRiordan.fs" />
     <Compile Include="Models\BarabasiAlbert.fs" />
     <Compile Include="Models\Gilbert.fs" />

--- a/src/FSharp.ArrayAdjacencyGraph/Measures.fs
+++ b/src/FSharp.ArrayAdjacencyGraph/Measures.fs
@@ -1,0 +1,158 @@
+namespace FSharp.FGL.ArrayAdjacencyGraph
+
+open System.Collections.Generic
+open System
+
+module Measures = 
+//Much of the logic is taken from the measure formulas detailed in the cytoscape documentation here 
+//https://med.bioinf.mpi-inf.mpg.de/netanalyzer/help/2.7/index.html#figure7
+
+    let private infinity = Double.PositiveInfinity 
+
+    // dijkstra implementation is based on and extended from the psuedo code here https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Pseudocode
+    // Didnt rewrite with recursion and immutability for performance and to keep it close to the psuedo code 
+    let private dijkstra(graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) 
+                        (edgeFinder: 'Vertex -> 'Vertex array) // used to filter directed/undirected edges
+                        (weightCalc: 'Vertex * 'Vertex -> float ) // can be controled for unweighted paths or domain specific use cases.
+                        (source: 'Vertex) = 
+
+        let q = new ResizeArray<'Vertex>()
+        let dist = new Dictionary<'Vertex, float>()
+
+        graph.GetVertices()
+        |> Array.iter(fun v ->   
+            q.Add v
+            if v <> source then 
+                dist.Add(v, infinity) 
+            else dist.Add(v, 0.0) )
+    
+        while q.Count > 0 do
+            dist
+            |> Seq.filter(fun (KeyValue(v,d)) -> q.Contains v)
+            |> Seq.minBy(fun (KeyValue(_ ,d)) -> d)
+            |> fun (KeyValue(v,_)) -> 
+                q.Remove v |> ignore
+                edgeFinder v
+                |> Array.iter(fun n -> 
+                    let alt = dist.[v] + (weightCalc (v, n))
+                    if alt < dist.[n] then dist.[n] <- alt; 
+                    ) 
+        dist
+        |> Seq.map(fun (KeyValue(v,d)) -> v, if d = infinity then None else Some d)
+        |> Map 
+
+    // all the weighted functions require Edge to be a float
+    let private getWeight (graph: ArrayAdjacencyGraph<'Vertex,'Label,float>) (v, n) = 
+        match graph.TryGetWeight(v, n) with
+                | Some w -> w
+                | None -> infinity 
+
+    let private meanShortestPathBase (vertexs: 'Vertex array) (fn: 'Vertex -> Map<'Vertex,option<float>> ) = 
+        vertexs
+        |> Seq.map(fun v ->  
+            fn v
+            |> Map.toSeq
+            |> Seq.choose(fun (_,v) -> v)
+        )
+        |> Seq.concat
+        |> Seq.filter (fun v -> v > 0.0)
+        |> Seq.average
+
+    /// Returns a Some of the undirected shortest path from source to target vertices, else None.         
+    let tryGetShortestPath (graph: ArrayAdjacencyGraph<'Vertex,'Label, 'Edge>) (source: 'Vertex) (target: 'Vertex) = 
+        (dijkstra graph graph.Neighbours (fun (n, v) -> 1.0) source).[target]
+
+    /// Returns a Some of the outward directed shortest path from source to target vertices, else None.       
+    let tryGetShortestPathDirected (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) (target: 'Vertex) = 
+        (dijkstra graph graph.Successors (fun (n, v) -> 1.0) source).[target]
+    
+    /// Returns a Some of the sum of edge weights along the outward directed shortest path from source to target vertices, else None.    
+    let tryGetShortestPathDirectedhWeighted (graph: ArrayAdjacencyGraph<'Vertex,'Label,float>) (source: 'Vertex) (target: 'Vertex) = 
+        (dijkstra graph graph.Successors (getWeight graph) source).[target]
+
+    /// Returns the average of all the undirected shortest paths between connected vertices in the graph
+    let meanShortestUnDirected (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) =
+        meanShortestPathBase (graph.GetVertices()) (dijkstra graph graph.Neighbours (fun (_, _) -> 1.0))
+    
+    /// Returns the average of all the directed shortest paths between connected vertices in the graph
+    let meanShortestPathDirected (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) =
+        meanShortestPathBase (graph.GetVertices()) (dijkstra graph graph.Successors (fun (_, _) -> 1.0))
+
+    /// Returns the average of all the summed weights on directed edges on shortest paths between connected vertices in the graph
+    let meanShortestPathDirectedhWeighted (graph: ArrayAdjacencyGraph<'Vertex,'Label,float>) =
+        meanShortestPathBase (graph.GetVertices()) (dijkstra graph graph.Successors (getWeight graph))
+   
+    let private meanShortestPathVertexBase (paths: Map<'Vertex,option<float>>) =
+        paths
+        |> Map.toSeq
+        |> Seq.choose(fun (_,v) -> v)
+        |> Seq.filter (fun v -> v > 0.0)
+        |> Seq.average
+
+    //Averages Shortest Paths
+    //  Currently lib doesnt seem to suppor weighted undirected nerworks so have left out functions to cover these. 
+    //  Support would require a new version of the getEdge functions.
+
+    /// Returns the average of all the shortest paths from the source vertex to the connected vertices
+    let meanShortestPathUnDirectedVertex (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
+        (dijkstra graph graph.Neighbours (fun (_, _) -> 1.0) source)
+        |> meanShortestPathVertexBase
+
+    /// Returns the average of all the outward directed shortest paths from the source vertex to the connected vertices
+    let meanShortestPathDirectedVertex (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
+        (dijkstra graph graph.Successors (fun (_, _) -> 1.0) source)
+        |> meanShortestPathVertexBase
+
+     /// Returns the average of all the summed weights on outward directed edges on shortest paths from the source vertex to the connected vertices
+    let meanShortestPathDirectedhWeightedVertex (graph: ArrayAdjacencyGraph<'Vertex,'Label,float>) (source: 'Vertex) =
+        (dijkstra graph graph.Successors (getWeight graph) source)
+        |> meanShortestPathVertexBase
+      
+    // Closeness
+    let private getClosenessBase (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) 
+                    (source: 'Vertex) 
+                    (edgeFinder: 'Vertex -> 'Vertex array) = 
+        dijkstra graph edgeFinder (fun (_, _) -> 1.0) source
+        |> Map.toSeq
+        |> Seq.choose(fun (k,v) -> v)
+        |> Seq.filter (fun v -> v > 0.0)
+        |> fun v -> 
+            1.0 / (v |> Seq.average) 
+    
+    /// Returns closeness centrality of the source vertex
+    let getClosenessUnDirected (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
+        getClosenessBase graph source (graph.Neighbours)
+
+    /// Returns outward directed closeness centrality of the source vertex
+    let getClosenessOutward (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
+        getClosenessBase graph source (graph.Successors)
+
+    /// Returns inward directed closeness centrality of the source vertex
+    let getClosenessInward (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
+        getClosenessBase graph source (graph.Predecessors)
+
+    /// Returns Neighborhood Connectivity as defined in cytoscape documentation for source vertex
+    let getNeighborhoodConnectivity(graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
+        graph.Neighbours source
+        |> Seq.map(fun v -> graph.Degree v |> float)
+        |> Seq.average
+
+    // Clustering Coeffcient 
+    let rec private combinations acc size set = seq {
+        match size, set with 
+        | n, x::xs -> 
+            if n > 0 then yield! combinations (x::acc) (n - 1) xs
+            if n >= 0 then yield! combinations acc n xs 
+        | 0, [] -> yield acc 
+        | _, [] -> () }
+
+    /// Returns Clustering Coeffcient as defined in cytoscape documentation for source vertex
+    let getClusteringCoefficient (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
+        graph.Neighbours source
+        |> Array.toList
+        |> combinations [] 2
+        |> Seq.map(fun l -> (l|> List.head), (l |> List.last))
+        |> Seq.map(fun (v1, v2) -> 
+            if graph.TryGetEdge(v1, v2).IsSome || (graph.TryGetEdge(v2, v1)).IsSome then 1.0 else 0.0 // ugly, lib needs a undirected TryGetEdge
+            )
+        |> fun s ->  (s |> Seq.sum) /(s |> Seq.length |> float)

--- a/src/FSharp.ArrayAdjacencyGraph/Measures.fs
+++ b/src/FSharp.ArrayAdjacencyGraph/Measures.fs
@@ -10,7 +10,7 @@ module Measures =
     let private infinity = Double.PositiveInfinity 
 
     // dijkstra implementation is based on and extended from the psuedo code here https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Pseudocode
-    // Didnt rewrite with recursion and immutability for performance and to keep it close to the psuedo code 
+    // Didnt rewrite with recursion and immutability for performance reasons and to keep it close to the psuedo code 
     let private dijkstra(graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) 
                         (edgeFinder: 'Vertex -> 'Vertex array) // used to filter directed/undirected edges
                         (weightCalc: 'Vertex * 'Vertex -> float ) // can be controled for unweighted paths or domain specific use cases.
@@ -47,8 +47,8 @@ module Measures =
                 | Some w -> w
                 | None -> infinity 
 
-    let private meanShortestPathBase (vertexs: 'Vertex array) (fn: 'Vertex -> Map<'Vertex,option<float>> ) = 
-        vertexs
+    let private meanShortestPathBase (vertices: 'Vertex array) (fn: 'Vertex -> Map<'Vertex,option<float>> ) = 
+        vertices
         |> Seq.map(fun v ->  
             fn v
             |> Map.toSeq
@@ -70,15 +70,15 @@ module Measures =
     let tryGetShortestPathDirectedhWeighted (graph: ArrayAdjacencyGraph<'Vertex,'Label,float>) (source: 'Vertex) (target: 'Vertex) = 
         (dijkstra graph graph.Successors (getWeight graph) source).[target]
 
-    /// Returns the average of all the undirected shortest paths between connected vertices in the graph
+    /// Returns the average of all the undirected shortest paths between connected vertices in the graph.
     let meanShortestUnDirected (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) =
         meanShortestPathBase (graph.GetVertices()) (dijkstra graph graph.Neighbours (fun (_, _) -> 1.0))
     
-    /// Returns the average of all the directed shortest paths between connected vertices in the graph
+    /// Returns the average of all the directed shortest paths between connected vertices in the graph.
     let meanShortestPathDirected (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) =
         meanShortestPathBase (graph.GetVertices()) (dijkstra graph graph.Successors (fun (_, _) -> 1.0))
 
-    /// Returns the average of all the summed weights on directed edges on shortest paths between connected vertices in the graph
+    /// Returns the average of all the summed weights on directed edges on shortest paths between connected vertices in the graph.
     let meanShortestPathDirectedhWeighted (graph: ArrayAdjacencyGraph<'Vertex,'Label,float>) =
         meanShortestPathBase (graph.GetVertices()) (dijkstra graph graph.Successors (getWeight graph))
    
@@ -90,20 +90,18 @@ module Measures =
         |> Seq.average
 
     //Averages Shortest Paths
-    //  Currently lib doesnt seem to suppor weighted undirected nerworks so have left out functions to cover these. 
-    //  Support would require a new version of the getEdge functions.
 
-    /// Returns the average of all the shortest paths from the source vertex to the connected vertices
+    /// Returns the average of all the shortest paths from the source vertex to the connected vertices.
     let meanShortestPathUnDirectedVertex (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
         (dijkstra graph graph.Neighbours (fun (_, _) -> 1.0) source)
         |> meanShortestPathVertexBase
 
-    /// Returns the average of all the outward directed shortest paths from the source vertex to the connected vertices
+    /// Returns the average of all the outward directed shortest paths from the source vertex to the connected vertices.
     let meanShortestPathDirectedVertex (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
         (dijkstra graph graph.Successors (fun (_, _) -> 1.0) source)
         |> meanShortestPathVertexBase
 
-     /// Returns the average of all the summed weights on outward directed edges on shortest paths from the source vertex to the connected vertices
+     /// Returns the average of all the summed weights on outward directed edges on shortest paths from the source vertex to the connected vertices.
     let meanShortestPathDirectedhWeightedVertex (graph: ArrayAdjacencyGraph<'Vertex,'Label,float>) (source: 'Vertex) =
         (dijkstra graph graph.Successors (getWeight graph) source)
         |> meanShortestPathVertexBase
@@ -119,19 +117,19 @@ module Measures =
         |> fun v -> 
             1.0 / (v |> Seq.average) 
     
-    /// Returns closeness centrality of the source vertex
+    /// Returns closeness centrality of the source vertex.
     let getClosenessUnDirected (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
         getClosenessBase graph source (graph.Neighbours)
 
-    /// Returns outward directed closeness centrality of the source vertex
+    /// Returns outward directed closeness centrality of the source vertex.
     let getClosenessOutward (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
         getClosenessBase graph source (graph.Successors)
 
-    /// Returns inward directed closeness centrality of the source vertex
+    /// Returns inward directed closeness centrality of the source vertex.
     let getClosenessInward (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
         getClosenessBase graph source (graph.Predecessors)
 
-    /// Returns Neighborhood Connectivity as defined in cytoscape documentation for source vertex
+    /// Returns Neighborhood Connectivity as defined in cytoscape documentation for source vertex.
     let getNeighborhoodConnectivity(graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
         graph.Neighbours source
         |> Seq.map(fun v -> graph.Degree v |> float)
@@ -146,13 +144,13 @@ module Measures =
         | 0, [] -> yield acc 
         | _, [] -> () }
 
-    /// Returns Clustering Coeffcient as defined in cytoscape documentation for source vertex
+    /// Returns Clustering Coeffcient as defined in cytoscape documentation for source vertex.
     let getClusteringCoefficient (graph: ArrayAdjacencyGraph<'Vertex,'Label,'Edge>) (source: 'Vertex) =
         graph.Neighbours source
         |> Array.toList
         |> combinations [] 2
         |> Seq.map(fun l -> (l|> List.head), (l |> List.last))
         |> Seq.map(fun (v1, v2) -> 
-            if graph.TryGetEdge(v1, v2).IsSome || (graph.TryGetEdge(v2, v1)).IsSome then 1.0 else 0.0 // ugly, lib needs a undirected TryGetEdge
+            if graph.TryGetEdge(v1, v2).IsSome || (graph.TryGetEdge(v2, v1)).IsSome then 1.0 else 0.0 
             )
         |> fun s ->  (s |> Seq.sum) /(s |> Seq.length |> float)

--- a/tests/FSharp.FGL.Tests/ArrayAdjacencyGraph.fs
+++ b/tests/FSharp.FGL.Tests/ArrayAdjacencyGraph.fs
@@ -186,6 +186,10 @@ let testEdges =
         testCase "GetEdges" (fun () ->
             
             let getEdge =
+
+
+
+
                 [
                     for i in exampleGraphEdges do
                         let (s,t,w) = i
@@ -942,4 +946,182 @@ let testLabels =
                 (sprintf "SetLabel does not correctly change the label %A" x)
         )
 
+    ]
+
+
+[<Tests>]
+let testMeasures =
+    let exampleGraphVertices =
+        [ for i=0 to 5 do (i,i) ]
+   
+    let exampleGraphEdges =
+        [
+            1,2,1.0//1,2,3,4
+            2,3,1.0//1,2,3
+            3,4,1.0//1,2
+            4,5,1.0//1
+            4,1,1.0
+        ]
+
+    let exampleGraphEdgesWeighted =
+        [
+            1,2,2.0//1,2,3,4
+            2,3,3.0//1,2,3
+            3,2,1.0//1,2,3
+            3,4,4.0//1,2
+            4,5,1.0//1
+            4,1,99.0
+        ]
+    let fig7Nodes = ["a","a"; "b","b";"c","c";"d","d";"e","e";]
+    let fig7 = 
+        [
+            "a","b",10.0
+            "b","c",1.0
+            "b","d", 1.0
+            "c","e",1.0
+            "d","e",1.0
+        ]
+
+    let fig4Nodes = ["a","a"; "b","b";"c","c";"d","d";]
+    let fig4 = 
+        [
+            "a","b",10.0
+            "b","c",1.0
+            "b","d", 1.0
+            "c","d",1.0
+        ]
+
+
+    let fig4Graph = FSharp.FGL.ArrayAdjacencyGraph.ArrayAdjacencyGraph(fig4Nodes,fig4)
+    let fig7Graph = FSharp.FGL.ArrayAdjacencyGraph.ArrayAdjacencyGraph(fig7Nodes,fig7)
+   
+    let testGraph = FSharp.FGL.ArrayAdjacencyGraph.ArrayAdjacencyGraph(exampleGraphVertices,exampleGraphEdges)
+    let weightedGraph = FSharp.FGL.ArrayAdjacencyGraph.ArrayAdjacencyGraph(exampleGraphVertices,exampleGraphEdgesWeighted)
+
+    testList "Test Measures" [
+        
+        // Undirected / Unweighted 
+        testCase "meanShortestPath" (fun () ->
+            let msp = Measures.meanShortestUnDirected fig7Graph
+            Expect.floatClose Accuracy.medium msp 1.6 "Incorrect mean shortest path does not return the correct label"
+        )
+
+        testCase "tryGetShortestPath" (fun () ->
+            let sp = Measures.tryGetShortestPath testGraph 1 5
+            Expect.isSome sp "Incorrect shortest path"     
+            Expect.equal sp.Value 2.0 "Incorrect shortest path"       
+        )
+
+        // Directed / Unweighted 
+        testCase "meanShortestPathDirected" (fun () ->
+            let msp = Measures.meanShortestPathDirected fig7Graph
+            Expect.floatClose Accuracy.medium msp 1.5555555555 "Incorrect mean shortest path does not return the correct label"
+        )
+
+        testCase "tryGetShortestPathDirected" (fun () ->
+            let sp = Measures.tryGetShortestPathDirected testGraph 1 5
+            Expect.isSome sp "Incorrect shortest path"     
+            Expect.equal sp.Value 4.0 "Incorrect shortest path"       
+        )
+
+        testCase "tryGetShortestPathDirected - reverse path" (fun () ->
+            let sp = Measures.tryGetShortestPathDirected testGraph 3 1
+            Expect.isSome sp "Incorrect shortest path"     
+            Expect.equal sp.Value 2.0 "Incorrect shortest path"       
+        )
+
+        testCase "tryGetShortestPathDirected - No path exists" (fun () ->
+            let sp = Measures.tryGetShortestPathDirected testGraph 5 1   
+            Expect.isNone sp "Incorrect shortest path"       
+        )
+
+        // Directed / Weighted 
+        testCase "meanShortestPathDirectedWeighted" (fun () ->
+            let msp = Measures.meanShortestPathDirectedhWeighted fig7Graph
+            Expect.floatClose Accuracy.medium msp 5.555555 "Incorrect mean shortest path does not return the correct label"
+        )
+
+        testCase "tryGetShortestPathDirectedWeighted" (fun () ->
+            let sp = Measures.tryGetShortestPathDirectedhWeighted fig7Graph "a" "c"
+            Expect.isSome sp "Incorrect shortest path"     
+            Expect.equal sp.Value 11.0 "Incorrect shortest path"       
+        )
+
+        //Vertex Mean shortest path
+        testCase "meanShortestPathUnDirectedVertex - A" (fun () ->
+            let sp = Measures.meanShortestPathUnDirectedVertex fig7Graph "a"   
+            Expect.floatClose Accuracy.medium sp 2.0 "Incorrect shortest path" 
+        )    
+         
+        testCase "meanShortestPathUnDirectedVertex - B" (fun () ->
+            let sp = Measures.meanShortestPathUnDirectedVertex fig7Graph "b"   
+            Expect.floatClose Accuracy.medium sp 1.25 "Incorrect shortest path"   
+        )
+        
+        testCase "meanShortestPathUnDirectedVertex - C" (fun () ->
+            let sp = Measures.meanShortestPathUnDirectedVertex fig7Graph "c"     
+            Expect.floatClose Accuracy.medium sp 1.5 "Incorrect shortest path"  
+        )
+
+        testCase "meanShortestPathUnDirectedVertex - D" (fun () ->
+            let sp = Measures.meanShortestPathUnDirectedVertex fig7Graph "d"     
+            Expect.floatClose Accuracy.medium sp 1.5 "Incorrect shortest path"  
+        )
+
+        testCase "meanShortestPathUnDirectedVertex - E" (fun () ->
+            let sp = Measures.meanShortestPathUnDirectedVertex fig7Graph "e"     
+            Expect.floatClose Accuracy.medium sp 1.75 "Incorrect shortest path"   
+        ) 
+
+        testCase "meanShortestPathDirectedVertex - B" (fun () ->
+            let sp = Measures.meanShortestPathDirectedVertex fig7Graph "b"     
+            Expect.floatClose Accuracy.medium sp 1.33333333333 "Incorrect shortest path"   
+        ) 
+
+        testCase "meanShortestPathDirectedhWeightedVertex - B" (fun () ->
+            let sp = Measures.meanShortestPathDirectedhWeightedVertex fig7Graph "a"     
+            Expect.floatClose Accuracy.medium sp 11.0 "Incorrect shortest path"   
+        ) 
+       
+        //Closeness
+        testCase "getClosenessUnDirected-A" (fun () ->
+            let sp = Measures.getClosenessUnDirected fig7Graph "a"  
+            Expect.floatClose Accuracy.medium sp 0.5 "Incorrect closeness"       
+        )
+        
+        testCase "getClosenessUnDirected-B" (fun () ->
+            let sp = Measures.getClosenessUnDirected fig7Graph "b"  
+            Expect.floatClose Accuracy.medium sp 0.8 "Incorrect closeness"       
+        )
+
+        testCase "getClosenessUnDirected-C" (fun () ->
+            let sp = Measures.getClosenessUnDirected fig7Graph "c"  
+            Expect.floatClose Accuracy.medium sp 0.6666666666666666 "Incorrect closeness"       
+        )
+
+        testCase "getClosenessUnDirected-D" (fun () ->
+            let sp = Measures.getClosenessUnDirected fig7Graph "d"  
+            Expect.floatClose Accuracy.medium sp 00.6666666666666666 "Incorrect closeness"       
+        )
+
+        testCase "getClosenessOutward" (fun () ->
+            let sp = Measures.getClosenessOutward fig7Graph "c"  
+            Expect.floatClose Accuracy.medium sp 1.0 "Incorrect closeness"       
+        )
+
+        testCase "getClosenessInward" (fun () ->
+            let sp = Measures.getClosenessInward fig7Graph "e"  
+            Expect.floatClose Accuracy.medium sp 0.5714285714285714 "Incorrect closeness"       
+        )
+        
+        testCase "getNNeighborhoodConnectivity" (fun () ->
+            let sp = Measures.getNeighborhoodConnectivity fig7Graph "d"  
+            Expect.floatClose Accuracy.medium sp 2.5 "Incorrect closeness"       
+        )
+
+        testCase "getClusteringCoefficient" (fun () ->
+            let sp = Measures.getClusteringCoefficient fig4Graph "b"  
+            Expect.floatClose Accuracy.medium sp 0.333333 "ClusteringCoefficient"       
+        )
+   
     ]

--- a/tests/FSharp.FGL.Tests/Main.fs
+++ b/tests/FSharp.FGL.Tests/Main.fs
@@ -12,4 +12,5 @@ let main argv =
     Tests.runTestsWithCLIArgs [] argv ArrayAdjacencyGraphTests.testEdges            |>ignore
     Tests.runTestsWithCLIArgs [] argv ArrayAdjacencyGraphTests.testVertices         |>ignore
     Tests.runTestsWithCLIArgs [] argv ArrayAdjacencyGraphTests.testLabels           |>ignore
+    Tests.runTestsWithCLIArgs [] argv ArrayAdjacencyGraphTests.testMeasures         |>ignore
     0


### PR DESCRIPTION
New functionality supporting the following:

Getting shortest path between two nodes (vertices). There are functions for undirected graphs, as well as directed, and directed and weighted graphs. 

Additionally, there are functions for getting the mean shortest path for an entire graph and for a single vertex.. 

I have also added functions to return Closeness Centrality for a given vertex. There are versions for undirected graphs, as well as inward and outward centrality for directed graphs. 

Lastly, I have added functions that return Neighborhood Connectivity for a given vertex in an undirected graph, and another function to the return the Clustering Coefficient.









